### PR TITLE
Changed node version 8 in Travis Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
 language: node_js
 node_js:
-  - "7"
-
-before_script:
-  - npm install -g gulp-cli
-script: gulp test
+  - "8"


### PR DESCRIPTION
nodeの最新リリースは8なので8を使用したほうがいいんじゃないでしょうか。