### PR TITLE
gulpを起動すると clean とbuildが実行されていたのを修正。

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,7 @@ gulp.task('clean', function() {
   return del(['dist']);
 });
 
-gulp.task('prepublish', runSequence(['build', 'clean']));
+gulp.task('prepublish', function () { return runSequence(['clean', 'build']) });
 
 gulp.task('default', ['watch']);
 


### PR DESCRIPTION
すみません。うっかりミスしてました。
gulp起動するだけで build して cleanが走ってました。