### PR TITLE
glupfile.js がeslintでエラーにならないようにルール調整

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,9 @@ rules:
   array-bracket-newline: error
   array-bracket-spacing: error
   array-callback-return: error
-  array-element-newline: error
+  array-element-newline:
+    - error
+    - minItems: 4
   arrow-body-style: error
   arrow-parens: error
   arrow-spacing: error
@@ -41,7 +43,9 @@ rules:
   consistent-this: error
   curly: error
   default-case: error
-  dot-location: error
+  dot-location:
+    - error
+    - property
   dot-notation:
     - error
     - allowKeywords: true

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 const gulp = require('gulp');
 const plugins = require("gulp-load-plugins")({
   lazy:false,
@@ -24,9 +25,7 @@ let publish = false;
 
 
 gulp.task("browser-sync", function () {
-  browserSync.init({
-    server: { baseDir: dir.demo + '/' }
-  });
+  browserSync.init({ server: { baseDir: dir.demo + '/' } });
 });
 
 
@@ -54,31 +53,35 @@ gulp.task('watch', function (cb) {
 });
 
 gulp.task('build', function () {
-  return rollup.rollup({
-    input: nSpeechPath
-  }).then(function (bundle) {
-    const amd = bundle.write({
-      file: dir.dist + '/index.amd.js',
-      format: "amd"
-    });
+  return rollup.rollup({ input: nSpeechPath })
+    .then(function (bundle) {
+      const amd = bundle.write({
+        file: dir.dist + '/index.amd.js',
+        format: "amd"
+      });
 
-    const cjs = bundle.write({
-      file: dir.dist + '/index.js',
-      format: "cjs"
-    });
+      const cjs = bundle.write({
+        file: dir.dist + '/index.js',
+        format: "cjs"
+      });
 
-    const es = bundle.write({
-      file: dir.dist + '/index.es.js',
-      format: "es"
-    });
+      const es = bundle.write({
+        file: dir.dist + '/index.es.js',
+        format: "es"
+      });
 
-    const iife = bundle.write({
-      file: dir.dist + '/nSpeech.js',
-      name: 'nSpeech',
-      format: 'iife'
-    });
+      const iife = bundle.write({
+        file: dir.dist + '/nSpeech.js',
+        name: 'nSpeech',
+        format: 'iife'
+      });
 
-    return Promise.all([amd, cjs, es, iife]);
+      return Promise.all([
+        amd,
+        cjs,
+        es,
+        iife
+      ]);
 
   });
 });


### PR DESCRIPTION
* array-elements-newline

 配列で4個以上の要素があるとき改行が必要

* dot-location

 プロパティアクセスするときドットは先頭位置

* env-node (gulpfile.js only)

requireでエラーがでないように